### PR TITLE
Add automatic parameter tuning utilities

### DIFF
--- a/scripts/auto_ai_tuner.py
+++ b/scripts/auto_ai_tuner.py
@@ -1,0 +1,43 @@
+"""CLI script to automatically tune .env parameters using AI suggestions."""
+
+from pathlib import Path
+from dotenv import load_dotenv
+
+from trading_bot.ai_helpers import ask_ai_parameter_tuning
+from trading_bot.env_utils import parse_suggestion, update_env_vars
+
+ENV_PATH = Path(".env")
+
+
+def main() -> None:
+    if ENV_PATH.exists():
+        load_dotenv(ENV_PATH)
+    else:
+        print(".env 파일을 찾을 수 없습니다.")
+        return
+
+    for attempt in range(3):
+        reply = ask_ai_parameter_tuning()
+        if not reply:
+            print("AI 응답을 받지 못했습니다.")
+            break
+
+        print(f"AI 제안({attempt+1}): {reply}")
+
+        if "더 이상 변경할 사항 없음" in reply:
+            print("AI가 더 이상 변경할 사항이 없다고 응답했습니다.")
+            break
+
+        params = parse_suggestion(reply)
+        if not params:
+            print("파싱된 파라미터가 없습니다. 다음 반복을 시도합니다.")
+            continue
+
+        update_env_vars(params, ENV_PATH)
+        load_dotenv(ENV_PATH, override=True)
+
+    print("auto_ai_tuner 완료")
+
+
+if __name__ == "__main__":
+    main()

--- a/trading_bot/env_utils.py
+++ b/trading_bot/env_utils.py
@@ -1,0 +1,48 @@
+"""Utility functions for .env parameter tuning."""
+
+from pathlib import Path
+import re
+from typing import Dict
+
+
+def parse_suggestion(text: str) -> Dict[str, str]:
+    """AI 응답 문자열에서 "KEY=VALUE" 쌍을 모두 추출해 dict로 반환."""
+    pairs = re.findall(r"([A-Z0-9_]+)\s*=\s*([^\s#]+)", text)
+    return {k.strip(): v.strip() for k, v in pairs}
+
+
+def update_env_vars(suggestions: Dict[str, str], env_path: Path) -> None:
+    """.env 파일을 suggestions 값으로 업데이트 후 덮어쓴 줄 끝에 '# [AI-TUNED]'를 추가."""
+    if not suggestions:
+        return
+
+    text = env_path.read_text(encoding="utf-8")
+    lines = text.splitlines()
+    updated_keys = set()
+    new_lines = []
+
+    for line in lines:
+        replaced = False
+        for key, val in suggestions.items():
+            if re.match(rf"\s*{re.escape(key)}\s*=", line):
+                indent = re.match(r"\s*", line).group(0)
+                comment = ""
+                if "#" in line:
+                    comment = line.split("#", 1)[1].strip()
+                new_line = f"{indent}{key}={val}"
+                if comment:
+                    new_line += f" #{comment} # [AI-TUNED]"
+                else:
+                    new_line += " # [AI-TUNED]"
+                new_lines.append(new_line)
+                updated_keys.add(key)
+                replaced = True
+                break
+        if not replaced:
+            new_lines.append(line)
+
+    for key, val in suggestions.items():
+        if key not in updated_keys:
+            new_lines.append(f"{key}={val} # [AI-TUNED]")
+
+    env_path.write_text("\n".join(new_lines) + "\n", encoding="utf-8")


### PR DESCRIPTION
## Summary
- add `parse_suggestion` and `update_env_vars` helpers for env management
- teach `ai_helpers` how to ask the model for parameter suggestions
- create `auto_ai_tuner.py` CLI for iterative tuning
- run `py_compile` to ensure syntax validity

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_683fd9c84b688325b264c12b48320b30