### PR TITLE
Enable recursive AI reflections and automatic tuning

### DIFF
--- a/trading_bot/executor.py
+++ b/trading_bot/executor.py
@@ -10,7 +10,6 @@ import requests
 
 from trading_bot.account_sync import sync_account_upbit
 from trading_bot.db_helpers import log_indicator, get_recent_trades
-from trading_bot.ai_helpers import ask_ai_reflection
 from trading_bot.config import LIVE_MODE, TICKER, DISCORD_WEBHOOK, PLAY_RATIO, MIN_ORDER_KRW
 
 logger = logging.getLogger(__name__)

--- a/trading_bot/main.py
+++ b/trading_bot/main.py
@@ -217,11 +217,20 @@ def ai_trading():
     if executed:
         try:
             recent_trades = get_recent_trades(limit=20)
-            from trading_bot.ai_helpers import ask_ai_reflection
-            reflection_text = ask_ai_reflection(recent_trades, ctx.fear_idx) or ""
+            from trading_bot.ai_helpers import ask_ai_reflection, apply_to_env
+            chart_recent = ctx.df_15m.tail(100)
+            reflection_text, updates = ask_ai_reflection(
+                recent_trades,
+                ctx.fear_idx,
+                chart_recent,
+                recursive=True,
+            )
             if reflection_text:
                 reflection_id = log_reflection(time.time(), reflection_text)
                 logger.info(f"반성문 저장 완료 (reflection_id={reflection_id})")
+            if updates:
+                apply_to_env(updates)
+                logger.info(f".env 업데이트: {updates}")
         except Exception as e:
             logger.exception(f"반성문 생성/저장 중 예외 발생: {e}")
             reflection_id = 0


### PR DESCRIPTION
## Summary
- enhance `ask_ai_reflection` to support chart data, recursion and return env suggestions
- add helper to update `.env` directly from AI output
- call the new reflection logic from `main` and apply env updates
- drop unused import in `executor`

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python -m pip install -r requirements.txt` *(fails: Tunnel connection failed 403)*

------
https://chatgpt.com/codex/tasks/task_e_683fb7221efc83259a87873de91c92db