### PR TITLE
Implement reflection cooldown setting

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -71,3 +71,7 @@ EXTREME_FEAR_THRESHOLD=10
 # 1시간봉 보조 지표 예외용 임계치
 RSI_OVERRIDE=60
 MACD_1H_THRESHOLD=5000
+
+# ──────────────────────────────────────────────
+# AI 반성문 최소 작성 간격(시간)
+REFLECTION_INTERVAL_HOURS=11

--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ gptbitcoin/
     MIN_ORDER_KRW=5000
     CACHE_TTL=3600
     FG_CACHE_TTL=82800
+    REFLECTION_INTERVAL_HOURS=11
     BASE_RISK=0.02
     ```
 
@@ -197,13 +198,20 @@ gptbitcoin/
      - 실거래 모드(`LIVE_MODE=true`)에서는 Upbit 시장가 주문  
      - 가상 모드에서는 DB 계좌에서 가상 계산만 수행
 
-9. **로그 기록 & Discord 알림**  
-   - `trading_bot/db_helpers.py`  
-     - SQLite 테이블: `account(id=1)`, `indicator_log`, `trade_log`, `reflection_log` (자동 생성)  
-   - `trading_bot/executor.py` → `log_and_notify()`  
-     - 매매 신호를 DB(`trade_log`)에 기록하고,  
-     - 실제 주문이 체결되었을 때만 Discord Webhook에 알림을 보냅니다.  
+9. **로그 기록 & Discord 알림**
+   - `trading_bot/db_helpers.py`
+     - SQLite 테이블: `account(id=1)`, `indicator_log`, `trade_log`, `reflection_log` (자동 생성)
+   - `trading_bot/executor.py` → `log_and_notify()`
+     - 매매 신호를 DB(`trade_log`)에 기록하고,
+     - 실제 주문이 체결되었을 때만 Discord Webhook에 알림을 보냅니다.
      - (`DISCORD_WEBHOOK`을 빈 문자열로 두면 알림이 가지 않습니다.)
+
+10. **AI 반성문 & 전략 자동 조정**
+   - 최근 거래 내역과 차트 데이터를 GPT-4o에 보내 간단한 반성문을 생성합니다.
+   - 새 반성문은 마지막 작성 이후 `REFLECTION_INTERVAL_HOURS`(기본 11시간) 이상
+     지나야만 저장됩니다.
+   - 반성문에 `KEY=VALUE` 형태가 포함되면 `.env` 파일에 자동 반영해 전략 수치를
+     업데이트합니다.
 
 ---
 

--- a/trading_bot/config.py
+++ b/trading_bot/config.py
@@ -1,6 +1,7 @@
 # trading_bot/config.py
 
 from dotenv import load_dotenv
+
 load_dotenv()
 
 import os
@@ -9,13 +10,13 @@ from pathlib import Path
 # ──────────────────────────────────────────────────────────────────────
 # 프로젝트 기본 경로 및 환경 변수 로드
 # ──────────────────────────────────────────────────────────────────────
-PROJECT_ROOT  = Path(__file__).resolve().parent
-DATA_DIR      = PROJECT_ROOT / "data"
+PROJECT_ROOT = Path(__file__).resolve().parent
+DATA_DIR = PROJECT_ROOT / "data"
 DATA_DIR.mkdir(exist_ok=True)
 
-DB_FILE       = DATA_DIR / "trading.db"
-CACHE_FILE    = DATA_DIR / "ohlcv_cache.json"
-LOG_DIR       = PROJECT_ROOT / "logs"
+DB_FILE = DATA_DIR / "trading.db"
+CACHE_FILE = DATA_DIR / "ohlcv_cache.json"
+LOG_DIR = PROJECT_ROOT / "logs"
 LOG_DIR.mkdir(exist_ok=True)
 
 # 패턴 히스토리 저장 파일 (ai_helpers.py에서 사용)
@@ -23,40 +24,39 @@ PATTERN_HISTORY_FILE = DATA_DIR / "pattern_history.json"
 # ──────────────────────────────────────────────────────────────────────
 
 # 1) 기본 환경 변수
-TICKER        = os.getenv("TICKER", "KRW-BTC")
-INTERVAL      = os.getenv("INTERVAL", "minute15")
-CACHE_TTL     = int(os.getenv("CACHE_TTL", "3600"))
-FG_CACHE_TTL  = int(os.getenv("FG_CACHE_TTL", "82800"))
+TICKER = os.getenv("TICKER", "KRW-BTC")
+INTERVAL = os.getenv("INTERVAL", "minute15")
+CACHE_TTL = int(os.getenv("CACHE_TTL", "3600"))
+FG_CACHE_TTL = int(os.getenv("FG_CACHE_TTL", "82800"))
 MIN_ORDER_KRW = int(os.getenv("MIN_ORDER_KRW", "5000"))
 
-ACCESS_KEY    = os.getenv("UPBIT_ACCESS_KEY", "").strip()
-SECRET_KEY    = os.getenv("UPBIT_SECRET_KEY", "").strip()
-LIVE_MODE     = (
-    os.getenv("LIVE_MODE", "false").lower() == "true"
-    and ACCESS_KEY and SECRET_KEY
+ACCESS_KEY = os.getenv("UPBIT_ACCESS_KEY", "").strip()
+SECRET_KEY = os.getenv("UPBIT_SECRET_KEY", "").strip()
+LIVE_MODE = (
+    os.getenv("LIVE_MODE", "false").lower() == "true" and ACCESS_KEY and SECRET_KEY
 )
 
 DISCORD_WEBHOOK = os.getenv("DISCORD_WEBHOOK_URL", "").strip()
 
-PLAY_RATIO    = float(os.getenv("PLAY_RATIO", "0.05"))
+PLAY_RATIO = float(os.getenv("PLAY_RATIO", "0.05"))
 RESERVE_RATIO = float(os.getenv("RESERVE_RATIO", "0.10"))
 
 # 2) 가상 계좌 기본값
-INITIAL_KRW  = float(os.getenv("INITIAL_KRW", "30000.0"))
+INITIAL_KRW = float(os.getenv("INITIAL_KRW", "30000.0"))
 
 # 3) “Fear & Greed” 지수 임계치
-FG_BUY_TH    = int(os.getenv("FG_BUY_TH", "40"))
-FG_SELL_TH   = int(os.getenv("FG_SELL_TH", "70"))
+FG_BUY_TH = int(os.getenv("FG_BUY_TH", "40"))
+FG_SELL_TH = int(os.getenv("FG_SELL_TH", "70"))
 FG_EXTREME_FEAR = int(os.getenv("FG_EXTREME_FEAR", "50"))
 
 # 4) 전략 관련 파라미터
 
 # 4.1) 이동평균/지표 윈도우
-SMA_WINDOW      = int(os.getenv("SMA_WINDOW", "30"))
+SMA_WINDOW = int(os.getenv("SMA_WINDOW", "30"))
 EMA_FAST_WINDOW = int(os.getenv("EMA_FAST_WINDOW", "12"))
 EMA_SLOW_WINDOW = int(os.getenv("EMA_SLOW_WINDOW", "26"))
-RSI_WINDOW      = int(os.getenv("RSI_WINDOW", "14"))
-ATR_WINDOW      = int(os.getenv("ATR_WINDOW", "16"))
+RSI_WINDOW = int(os.getenv("RSI_WINDOW", "14"))
+ATR_WINDOW = int(os.getenv("ATR_WINDOW", "16"))
 
 # 4.2) 볼륨 스파이크 임계치
 _raw = os.getenv("VOLUME_SPIKE_THRESHOLD", "0.25")
@@ -73,21 +73,21 @@ _raw = os.getenv("PRICE_RANGE_THRESHOLD", "0.10")
 PRICE_RANGE_THRESHOLD = float(_raw.split("#", 1)[0].strip())
 
 # 4.4) 손절/익절 비율
-STOP_LOSS_PCT    = float(os.getenv("STOP_LOSS_PCT", "0.06"))
-TAKE_PROFIT_PCT  = float(os.getenv("TAKE_PROFIT_PCT", "0.05"))
+STOP_LOSS_PCT = float(os.getenv("STOP_LOSS_PCT", "0.06"))
+TAKE_PROFIT_PCT = float(os.getenv("TAKE_PROFIT_PCT", "0.05"))
 
 # 4.5) 매매 수수료 (Upbit 시장가)
-TRADING_FEE      = float(os.getenv("TRADING_FEE", "0.0005"))
+TRADING_FEE = float(os.getenv("TRADING_FEE", "0.0005"))
 
 # 4.6) EMA 교차 밴드 임계치 (whipsaw 완화)
-EMA_CROSS_BAND  = float(os.getenv("EMA_CROSS_BAND", "0.5"))
+EMA_CROSS_BAND = float(os.getenv("EMA_CROSS_BAND", "0.5"))
 
 # 5) 캔들 패턴 관련 파라미터
 
-DOJI_TOLERANCE              = float(os.getenv("DOJI_TOLERANCE", "0.001"))
-DOUBLE_BOTTOM_REBOUND_PCT   = float(os.getenv("DOUBLE_BOTTOM_REBOUND_PCT", "0.01"))
-DOUBLE_TOP_DROP_PCT         = float(os.getenv("DOUBLE_TOP_DROP_PCT", "0.01"))
-DOUBLE_PATTERN_LOOKBACK     = int(os.getenv("DOUBLE_PATTERN_LOOKBACK", "3"))
+DOJI_TOLERANCE = float(os.getenv("DOJI_TOLERANCE", "0.001"))
+DOUBLE_BOTTOM_REBOUND_PCT = float(os.getenv("DOUBLE_BOTTOM_REBOUND_PCT", "0.01"))
+DOUBLE_TOP_DROP_PCT = float(os.getenv("DOUBLE_TOP_DROP_PCT", "0.01"))
+DOUBLE_PATTERN_LOOKBACK = int(os.getenv("DOUBLE_PATTERN_LOOKBACK", "3"))
 
 # 6) 1시간봉 SMA50 예외용 파라미터
 
@@ -99,3 +99,7 @@ MACD_1H_THRESHOLD = float(_raw.split("#", 1)[0].strip())
 
 _raw = os.getenv("FG_EXTREME_FEAR", "50.0")
 FG_EXTREME_FEAR = float(_raw.split("#", 1)[0].strip())
+
+# 7) AI 반성문 관련 설정
+REFLECTION_INTERVAL_HOURS = float(os.getenv("REFLECTION_INTERVAL_HOURS", "11"))
+REFLECTION_INTERVAL_SEC = int(REFLECTION_INTERVAL_HOURS * 3600)


### PR DESCRIPTION
## Summary
- add reflection cooldown option to `.env.sample`
- document `REFLECTION_INTERVAL_HOURS` in README
- cache AI reflection for 11 hours instead of 24
- expose reflection interval via `config.py`
- skip reflection generation until the cooldown passes

## Testing
- `black trading_bot/ai_helpers.py trading_bot/config.py trading_bot/main.py`
- `python -m py_compile trading_bot/ai_helpers.py trading_bot/config.py trading_bot/main.py`
- `python -m trading_bot.main --mode intraday --help` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_683ff70dbe7c8325abd8bfd07384d322