### PR TITLE
Fix hourly data fetch and env locking

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -2,7 +2,6 @@ LIVE_MODE=true
 UPBIT_ACCESS_KEY=
 UPBIT_SECRET_KEY=
 OPENAI_API_KEY=
-SERPAPI_API_KEY=
 DISCORD_WEBHOOK_URL=
 
 TICKER=KRW-BTC
@@ -64,9 +63,9 @@ EMA_CROSS_BAND=0.1
 # ──────────────────────────────────────────────
 # 7) 1h SMA50 예외 룰 관련
 #    - RSI가 과매도인 경우(예: 30 이하) 예외 허용
-RSI_OVERSOLD_THRESHOLD=30
+# (더 이상 사용되지 않음)
 #    - Fear-Greed 지수가 극단적 공포(예: 10 이하)일 때 예외 허용
-EXTREME_FEAR_THRESHOLD=10
+# (더 이상 사용되지 않음)
 
 # ──────────────────────────────────────────────────────
 # 1시간봉 보조 지표 예외용 임계치

--- a/trading_bot/data_fetcher.py
+++ b/trading_bot/data_fetcher.py
@@ -4,7 +4,14 @@ import pandas as pd
 import logging
 from typing import Optional
 
-from trading_bot.data_io import load_cached_ohlcv, save_cached_ohlcv, safe_ohlcv, fetch_direct
+import pyupbit
+from trading_bot.data_io import (
+    load_cached_ohlcv,
+    save_cached_ohlcv,
+    safe_ohlcv,
+    fetch_direct,
+    fetch_ohlcv_1h_via_rest,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -44,13 +51,18 @@ def fetch_data_1h(ticker: str, count: int = 100) -> Optional[pd.DataFrame]:
     실패 시 None 반환.
     """
     try:
-        df = fetch_direct()  # fetch_direct 내부에서 pyupbit도 호출함
-        if df is not None and not df.empty:
-            return df
+        df = pyupbit.get_ohlcv(ticker, interval="minute60", count=count)
+        if df is None or df.empty:
+            raise RuntimeError("pyupbit.get_ohlcv 빈 데이터")
+        return df[["open", "high", "low", "close", "volume"]]
+    except Exception:
+        logger.warning("pyupbit.get_ohlcv 실패 → REST 백업 시도")
+        try:
+            df = fetch_ohlcv_1h_via_rest(ticker, count)
+            if df is not None and not df.empty:
+                return df
+        except Exception:
+            logger.exception("fetch_ohlcv_1h_via_rest 실패")
 
         logger.error("fetch_data_1h: 데이터 없음, None 반환")
-        return None
-
-    except Exception as e:
-        logger.exception(f"fetch_data_1h() 예외 발생: {e}")
         return None


### PR DESCRIPTION
## Summary
- correct 1h OHLCV retrieval to use real hourly candles
- guard `.env` updates with file locking
- remove unused env vars from sample

## Testing
- `python -m py_compile trading_bot/data_fetcher.py trading_bot/ai_helpers.py`
- `python -m trading_bot.main --help` *(fails: ModuleNotFoundError: No module named 'pandas')*


------
https://chatgpt.com/codex/tasks/task_e_6848f741d2148325aae6cd67f031878e