### PR TITLE
Add REFLECTION_RECURSIVE option

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -75,3 +75,4 @@ MACD_1H_THRESHOLD=5000
 # ──────────────────────────────────────────────
 # AI 반성문 최소 작성 간격(시간)
 REFLECTION_INTERVAL_HOURS=11
+REFLECTION_RECURSIVE=true

--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ gptbitcoin/
     CACHE_TTL=3600
     FG_CACHE_TTL=82800
     REFLECTION_INTERVAL_HOURS=11
+    REFLECTION_RECURSIVE=true
     BASE_RISK=0.02
     ```
 
@@ -212,11 +213,13 @@ gptbitcoin/
    - 새 반성문은 마지막 작성 이후 `REFLECTION_INTERVAL_HOURS`(기본 11시간) 이상
      지나야만 저장되며, 매매가 없더라도 주기적으로 실행됩니다.
 
-   - 프롬프트는 반드시 `KEY=VALUE` 형식의 전략 조정안을 포함하도록 명시하며,
-     이 형식이 감지되면 `.env` 파일에 자동 반영해 전략 수치를 업데이트합니다.
-   - 만약 반성문에 `KEY=VALUE` 줄이 없을 경우, 최소 한 줄을 얻을 때까지 한 번 더
-     재요청합니다.
-     값은 숫자나 `true`/`false` 등 대부분의 기본 타입을 인식합니다.
+    - 프롬프트는 반드시 `KEY=VALUE` 형식의 전략 조정안을 포함하도록 명시하며,
+      이 형식이 감지되면 `.env` 파일에 자동 반영해 전략 수치를 업데이트합니다.
+    - 만약 반성문에 `KEY=VALUE` 줄이 없을 경우, 최소 한 줄을 얻을 때까지 한 번 더
+      재요청합니다.
+      값은 숫자나 `true`/`false` 등 대부분의 기본 타입을 인식합니다.
+    - 기본적으로 GPT에게 한 차례 추가 개선을 요청하지만,
+      `REFLECTION_RECURSIVE=false`로 설정하면 첫 응답만 사용합니다.
 
 
 ## 🛡️ 보안 주의 사항

--- a/trading_bot/ai_helpers.py
+++ b/trading_bot/ai_helpers.py
@@ -164,7 +164,7 @@ def ask_ai_reflection(
         )
         reflection = resp.choices[0].message.content.strip()
 
-        if recursive:
+        if recursive and max_iter > 1:
             for _ in range(max_iter - 1):
                 follow = (
                     "Here is your previous reflection:\n"

--- a/trading_bot/config.py
+++ b/trading_bot/config.py
@@ -111,3 +111,5 @@ FG_EXTREME_FEAR = float(_raw.split("#", 1)[0].strip())
 # 7) AI 반성문 관련 설정
 REFLECTION_INTERVAL_HOURS = float(os.getenv("REFLECTION_INTERVAL_HOURS", "11"))
 REFLECTION_INTERVAL_SEC = int(REFLECTION_INTERVAL_HOURS * 3600)
+# AI 리플렉션을 GPT에게 한 번 더 개선 요청할지 여부 (기본 true)
+REFLECTION_RECURSIVE = os.getenv("REFLECTION_RECURSIVE", "true").lower() == "true"

--- a/trading_bot/main.py
+++ b/trading_bot/main.py
@@ -39,6 +39,7 @@ from trading_bot.config import (
     MACD_1H_THRESHOLD,
     FG_EXTREME_FEAR,
     REFLECTION_INTERVAL_SEC,
+    REFLECTION_RECURSIVE,
 )
 
 # 디버그 로그가 보이도록 레벨을 DEBUG로 설정
@@ -249,7 +250,7 @@ def ai_trading():
                 recent_trades,
                 ctx.fear_idx,
                 chart_recent,
-                recursive=True,
+                recursive=REFLECTION_RECURSIVE,
             )
             if reflection_text:
                 reflection_id = log_reflection(time.time(), reflection_text)


### PR DESCRIPTION
## Summary
- allow disabling recursive AI reflection with env setting
- pass config option to `ask_ai_reflection`
- document `REFLECTION_RECURSIVE` in README and `.env.sample`
- minor tweak in `ask_ai_reflection` logic

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6861ebac613c8325b323cec80f2ae6e8