### PR TITLE
Implement DB log pruning and rotating logging

### DIFF
--- a/trading_bot/config.py
+++ b/trading_bot/config.py
@@ -112,3 +112,6 @@ REFLECTION_INTERVAL_HOURS = float(os.getenv("REFLECTION_INTERVAL_HOURS", "11"))
 REFLECTION_INTERVAL_SEC = int(REFLECTION_INTERVAL_HOURS * 3600)
 # AI 리플렉션을 GPT에게 한 번 더 개선 요청할지 여부 (기본 true)
 REFLECTION_RECURSIVE = os.getenv("REFLECTION_RECURSIVE", "true").lower() == "true"
+
+# 8) 데이터베이스 로그 보존 최대 행 수
+LOG_RETENTION_ROWS = int(os.getenv("LOG_RETENTION_ROWS", "5000"))


### PR DESCRIPTION
## Summary
- keep DB log tables small via `prune_old_logs`
- rotate cron log automatically using `RotatingFileHandler`
- expose `LOG_RETENTION_ROWS` configuration
- clean up logs at the start of `ai_trading`

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68620e1a2278832599dc1876e19c8804