### PR TITLE
Add warning when AI reflection lacks tweaks

### DIFF
--- a/trading_bot/ai_helpers.py
+++ b/trading_bot/ai_helpers.py
@@ -194,6 +194,11 @@ def ask_ai_reflection(
             params = parse_env_suggestions(reflection)
             tries += 1
 
+        if not params:
+            logger.warning(
+                "No KEY=VALUE suggestions after retries; keeping defaults."
+            )
+
         result = (reflection, params)
         _reflection_cache.set(key, result)
         _save_reflection_cache()


### PR DESCRIPTION
## Summary
- log if AI reflection returns no KEY=VALUE suggestions after retry attempts

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6862268694a0832583bb8c20e5a40b6c