### PR TITLE
Add configurable KV retry for AI reflection

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ gptbitcoin/
     FG_CACHE_TTL=82800
     REFLECTION_INTERVAL_HOURS=11
     REFLECTION_RECURSIVE=true
+    REFLECTION_KV_RETRY=2
     BASE_RISK=0.02
     ```
 
@@ -216,8 +217,9 @@ gptbitcoin/
 
     - 프롬프트는 반드시 `KEY=VALUE` 형식의 전략 조정안을 포함하도록 명시하며,
       이 형식이 감지되면 `.env` 파일에 자동 반영해 전략 수치를 업데이트합니다.
-    - 만약 반성문에 `KEY=VALUE` 줄이 없을 경우, 최소 한 줄을 얻을 때까지 한 번 더
-      재요청합니다. If no KEY=VALUE line is returned even after the second request,
+    - 만약 반성문에 `KEY=VALUE` 줄이 없을 경우,
+      최소 한 줄을 얻을 때까지 `REFLECTION_KV_RETRY`회(기본 2) 재요청합니다.
+      If no KEY=VALUE line is returned even after all retries,
       the bot keeps the existing `.env` values without modification.
       값은 숫자나 `true`/`false` 등 대부분의 기본 타입을 인식합니다.
     - 기본적으로 GPT에게 한 차례 추가 개선을 요청하지만,

--- a/trading_bot/ai_helpers.py
+++ b/trading_bot/ai_helpers.py
@@ -13,7 +13,11 @@ from openai import OpenAI
 import requests
 import fcntl
 
-from trading_bot.config import PATTERN_HISTORY_FILE, REFLECTION_CACHE_FILE
+from trading_bot.config import (
+    PATTERN_HISTORY_FILE,
+    REFLECTION_CACHE_FILE,
+    REFLECTION_KV_RETRY,
+)
 
 logger = logging.getLogger(__name__)
 OPENAI_KEY = os.getenv("OPENAI_API_KEY", "")
@@ -180,7 +184,7 @@ def ask_ai_reflection(
         params = parse_env_suggestions(reflection)
 
         tries = 0
-        while not params and tries < 2:
+        while not params and tries < REFLECTION_KV_RETRY:
             follow_up = (
                 "The previous reflection lacked KEY=VALUE tweaks. "
                 "Provide at least one KEY=VALUE line."

--- a/trading_bot/config.py
+++ b/trading_bot/config.py
@@ -112,6 +112,8 @@ REFLECTION_INTERVAL_HOURS = float(os.getenv("REFLECTION_INTERVAL_HOURS", "11"))
 REFLECTION_INTERVAL_SEC = int(REFLECTION_INTERVAL_HOURS * 3600)
 # AI 리플렉션을 GPT에게 한 번 더 개선 요청할지 여부 (기본 true)
 REFLECTION_RECURSIVE = os.getenv("REFLECTION_RECURSIVE", "true").lower() == "true"
+# KEY=VALUE 줄이 없을 때 추가 요청 시도 횟수 (기본 2)
+REFLECTION_KV_RETRY = int(os.getenv("REFLECTION_KV_RETRY", "2"))
 
 # 8) 데이터베이스 로그 보존 최대 행 수
 LOG_RETENTION_ROWS = int(os.getenv("LOG_RETENTION_ROWS", "5000"))


### PR DESCRIPTION
## Summary
- add `REFLECTION_KV_RETRY` env var and use it in ai_helpers
- update README with new variable description and usage

## Testing
- `pytest -q`
- `python -m py_compile trading_bot/*.py scripts/*.py`


------
https://chatgpt.com/codex/tasks/task_e_686227971dc88325b15940bd9a72793f