### PR TITLE
Reset avg_price on full sell

### DIFF
--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -1,0 +1,39 @@
+import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
+import sys
+
+# Provide dummy pyupbit module if missing
+if 'pyupbit' not in sys.modules:
+    sys.modules['pyupbit'] = SimpleNamespace(Upbit=lambda *a, **k: None)
+if 'requests' not in sys.modules:
+    sys.modules['requests'] = SimpleNamespace(post=lambda *a, **k: None)
+if 'pandas' not in sys.modules:
+    sys.modules['pandas'] = SimpleNamespace(DataFrame=object)
+if 'dotenv' not in sys.modules:
+    sys.modules['dotenv'] = SimpleNamespace(load_dotenv=lambda *a, **k: None)
+
+from trading_bot.executor import execute_trade
+from trading_bot.config import LIVE_MODE
+
+class ExecuteTradeTest(unittest.TestCase):
+    def test_avg_price_reset_on_full_sell(self):
+        if LIVE_MODE:
+            self.skipTest("LIVE_MODE enabled")
+        ctx = SimpleNamespace(
+            equity=100000.0,
+            krw=0.0,
+            btc=0.1,
+            avg_price=50000.0,
+            price=500000.0,
+            atr15=0.0,
+        )
+        with patch('trading_bot.executor.save_account') as mock_save:
+            executed, pct = execute_trade(ctx, False, True, 'test')
+            self.assertTrue(executed)
+            self.assertEqual(ctx.btc, 0.0)
+            self.assertEqual(ctx.avg_price, 0.0)
+            mock_save.assert_called_once()
+
+if __name__ == '__main__':
+    unittest.main()

--- a/trading_bot/executor.py
+++ b/trading_bot/executor.py
@@ -93,12 +93,16 @@ def execute_trade(
                 else:
                     ctx.krw += value
                     ctx.btc -= qty
+                    if ctx.btc == 0:
+                        ctx.avg_price = 0.0
                 pct_used = 100.0
 
         # 실제 모드 주문 후 잔고 재동기화
         if LIVE_MODE and executed:
             new_krw, new_btc, new_avg = sync_account_upbit()
             ctx.krw, ctx.btc, ctx.avg_price = new_krw, new_btc, new_avg
+            if ctx.btc == 0:
+                ctx.avg_price = 0.0
         elif executed:
             save_account(ctx.krw, ctx.btc, ctx.avg_price)
 


### PR DESCRIPTION
## Summary
- reset avg_price when all BTC has been sold off
- reflect reset in both live and virtual modes
- unit test execute_trade to ensure avg_price gets cleared

## Testing
- `python -m unittest discover -v tests`

------
https://chatgpt.com/codex/tasks/task_e_6863329a3404832597f02100784556d0