### PR TITLE
Add API key warning for AI helpers

### DIFF
--- a/trading_bot/ai_helpers.py
+++ b/trading_bot/ai_helpers.py
@@ -22,6 +22,10 @@ from trading_bot.config import (
 logger = logging.getLogger(__name__)
 OPENAI_KEY = os.getenv("OPENAI_API_KEY", "")
 client = OpenAI(api_key=OPENAI_KEY) if OPENAI_KEY else None
+if client is None:
+    logger.warning(
+        "OPENAI_API_KEY not set; AI features disabled (returns 'hold')"
+    )
 
 
 # ──────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- warn if `OPENAI_API_KEY` is empty when creating the OpenAI client

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686cf2254a348325b4d3f9dd64259f7a