### PR TITLE
Resolve env path automatically

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,9 @@ gptbitcoin/
 
     > ⚠️ **주의:** `.env` 파일에 민감한 API 키를 절대 공개 저장소에 커밋하지 마세요.
 
+    `trading_bot.config` 모듈이 저장소 루트의 `.env` 파일을 자동으로 로드하므로
+    크론 작업에서 작업 디렉터리를 별도로 변경할 필요가 없습니다.
+
 4. **데이터베이스 & 캐시 초기화**
 
     - 첫 실행 시 `trading_bot/config.py` 에서 지정한 경로(기본 `trading_bot/data/trading.db`)에 DB 파일이 자동 생성됩니다.
@@ -118,8 +121,8 @@ gptbitcoin/
          #!/usr/bin/env bash
          set -euo pipefail
 
-         # 1) 리포지토리 최신화
-         cd /home/ubuntu/gptbitcoin
+        # 1) (선택) 리포지토리 최신화
+        cd /home/ubuntu/gptbitcoin  # .env 로드를 위한 작업 디렉터리 변경은 필요 없음
 
          # 2) 가상환경 활성화
          source /home/ubuntu/gptbitcoin/venv/bin/activate

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,17 @@
+import sys
+import importlib
+from pathlib import Path
+from unittest.mock import patch
+import unittest
+
+class ConfigEnvPathTest(unittest.TestCase):
+    def test_load_dotenv_called_with_resolved_path(self):
+        sys.modules.pop('trading_bot.config', None)
+        with patch('dotenv.load_dotenv') as mock_load:
+            import trading_bot.config as cfg
+            expected = Path(cfg.__file__).resolve().parent.parent / ".env"
+            mock_load.assert_called_once_with(expected)
+
+if __name__ == '__main__':
+    unittest.main()
+

--- a/trading_bot/config.py
+++ b/trading_bot/config.py
@@ -1,13 +1,13 @@
 # trading_bot/config.py
 
 from dotenv import load_dotenv
+from pathlib import Path
 
-# 환경 변수는 .env 파일에서 로드합니다
-
-load_dotenv(".env")
+# 환경 변수는 저장소 루트의 .env 파일에서 로드합니다
+ENV_PATH = Path(__file__).resolve().parent.parent / ".env"
+load_dotenv(ENV_PATH)
 
 import os
-from pathlib import Path
 
 # ──────────────────────────────────────────────────────────────────────
 # 프로젝트 기본 경로 및 환경 변수 로드


### PR DESCRIPTION
## Summary
- load `.env` using an absolute path in `trading_bot.config`
- document automatic `.env` loading and note that cron jobs don't need to set the working directory
- add regression test for load path

## Testing
- `PYTHONPATH=$PWD pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6874568f1cc4832597ac817f6976fd7b