### PR TITLE
Fix project path in deploy script

### DIFF
--- a/deploy_and_run.sh
+++ b/deploy_and_run.sh
@@ -2,10 +2,11 @@
 set -euo pipefail
 
 # 1) 리포지토리 최신화
-cd /home/ubuntu/gptbitcoin
+PROJECT_DIR="$(cd "$(dirname "$0")" && pwd)"
+cd "$PROJECT_DIR"
 
 # 2) 가상환경 활성화
-source /home/ubuntu/gptbitcoin/venv/bin/activate
+source "$PROJECT_DIR/venv/bin/activate"
 
 # 3) 의존성 설치 (필요 시)
 pip install --upgrade pip
@@ -14,5 +15,5 @@ pip install -r requirements.txt
 # 4) 자동매매 스크립트 실행
 #    전달받은 모든 인자($@)를 python3 -m trading_bot.main 에 넘겨 줍니다.
 #    로그는 trading_bot/logs/cron.log 에 append
-python3 -m trading_bot.main "$@" >> /home/ubuntu/gptbitcoin/trading_bot/logs/cron.log 2>&1
+python3 -m trading_bot.main "$@" >> "$PROJECT_DIR/trading_bot/logs/cron.log" 2>&1
 


### PR DESCRIPTION
## Summary
- make deployment script resolve project directory dynamically

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'trading_bot')*

------
https://chatgpt.com/codex/tasks/task_e_6875f2e539cc83258c95fa9d3fb0f9dd