### PR TITLE
Add env debug logging

### DIFF
--- a/trading_bot/ai_helpers.py
+++ b/trading_bot/ai_helpers.py
@@ -445,12 +445,16 @@ def ask_pattern_decision(pattern_name: str, recent_data: pd.DataFrame) -> str:
     - 패턴 이름 + 최근 10봉 상황이 동일하면 5분간 캐시된 결정 재사용
     - 패턴 히스토리가 빈 상태일 때 유연한 힌트 제공
     """
+    logger.info(f"ask_pattern_decision 호출: pattern='{pattern_name}'")
+
     if client is None:
+        logger.info("OpenAI client 없음 → 'hold' 반환")
         return "hold"
 
     key = ("pattern_decision", pattern_name, _df_hashable_key(recent_data, rows=10))
     cached = _pattern_decision_cache.get(key)
     if cached is not None:
+        logger.debug(f"캐시된 결정 재사용: {cached}")
         return cached
 
     df_for_ai = (
@@ -511,6 +515,7 @@ def ask_pattern_decision(pattern_name: str, recent_data: pd.DataFrame) -> str:
         else:
             decision = "hold"
         _pattern_decision_cache.set(key, decision)
+        logger.info(f"ask_pattern_decision 결과: {decision}")
         return decision
     except Exception:
         logger.exception("ask_pattern_decision() 호출 중 예외 발생")

--- a/trading_bot/config.py
+++ b/trading_bot/config.py
@@ -2,10 +2,19 @@
 
 from dotenv import load_dotenv
 from pathlib import Path
+import logging
 
 # 환경 변수는 저장소 루트의 .env 파일에서 로드합니다
 ENV_PATH = Path(__file__).resolve().parent.parent / ".env"
 load_dotenv(ENV_PATH)
+
+logger = logging.getLogger(__name__)
+
+def log_env_info() -> None:
+    """Log .env path and OPENAI_API_KEY value for debugging."""
+    logger.info(
+        f".env 경로: {ENV_PATH}, OPENAI_API_KEY={os.getenv('OPENAI_API_KEY')}"
+    )
 
 import os
 

--- a/trading_bot/main.py
+++ b/trading_bot/main.py
@@ -32,6 +32,7 @@ from trading_bot.db_helpers import (
     prune_old_logs,
 )
 from trading_bot.utils import get_fear_and_greed
+import trading_bot.config as cfg
 from trading_bot.config import (
     LIVE_MODE,
     TICKER,
@@ -56,6 +57,8 @@ logging.basicConfig(
         logging.StreamHandler(),
     ],
 )
+
+cfg.log_env_info()
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
## Summary
- log `.env` path and API key on startup
- trace pattern decision AI calls for easier cron debugging

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68773c600e3c8325b2ca6d7b9168651f