### PR TITLE
Mask OPENAI key in logs

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -13,6 +13,18 @@ class ConfigEnvPathTest(unittest.TestCase):
             expected = Path(cfg.__file__).resolve().parent.parent / ".env"
             mock_load.assert_called_once_with(expected)
 
+
+class ConfigLogEnvInfoTest(unittest.TestCase):
+    def test_openai_api_key_masked_in_log(self):
+        sys.modules.pop('trading_bot.config', None)
+        with patch('dotenv.load_dotenv'), patch.dict(os.environ, {"OPENAI_API_KEY": "abcd1234efgh5678"}):
+            import trading_bot.config as cfg
+            with self.assertLogs(cfg.logger, level="INFO") as cm:
+                cfg.log_env_info()
+            log_output = "\n".join(cm.output)
+            self.assertNotIn("abcd1234efgh5678", log_output)
+            self.assertIn("abcd...5678", log_output)
+
 if __name__ == '__main__':
     unittest.main()
 

--- a/trading_bot/config.py
+++ b/trading_bot/config.py
@@ -3,6 +3,7 @@
 from dotenv import load_dotenv
 from pathlib import Path
 import logging
+import os
 
 # 환경 변수는 저장소 루트의 .env 파일에서 로드합니다
 ENV_PATH = Path(__file__).resolve().parent.parent / ".env"
@@ -11,12 +12,15 @@ load_dotenv(ENV_PATH)
 logger = logging.getLogger(__name__)
 
 def log_env_info() -> None:
-    """Log .env path and OPENAI_API_KEY value for debugging."""
-    logger.info(
-        f".env 경로: {ENV_PATH}, OPENAI_API_KEY={os.getenv('OPENAI_API_KEY')}"
-    )
-
-import os
+    """Log .env path and masked OPENAI_API_KEY for debugging."""
+    key = os.getenv("OPENAI_API_KEY", "")
+    if key:
+        masked = (
+            f"{key[:4]}...{key[-4:]}" if len(key) > 8 else key[:1] + "***" + key[-1:]
+        )
+    else:
+        masked = "(empty)"
+    logger.info(f".env 경로: {ENV_PATH}, OPENAI_API_KEY={masked}")
 
 # ──────────────────────────────────────────────────────────────────────
 # 프로젝트 기본 경로 및 환경 변수 로드


### PR DESCRIPTION
## Summary
- mask OPENAI_API_KEY in config logger
- test that masking works

## Testing
- `python3 -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6879cdc7b2908325a4b75e0f6e63b3ec